### PR TITLE
Drop 2to3 setup option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,5 +123,4 @@ setup(
     test_suite='tests',
     test_loader='trytond.test_loader:Loader',
     tests_require=tests_require,
-    use_2to3=True,
 )


### PR DESCRIPTION
New setuptools versions stop deliberately building packages that use 2to3. See https://github.com/pypa/setuptools/issues/2769

This option should have been removed in commit https://github.com/calidae/authentication-dummy/commit/3aeb6ff88180f9d70dbdcb67dffb7596b22f462e